### PR TITLE
Add MealThinker to Food-related projects

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,6 +40,7 @@
 - [diy-proofing-box](https://github.com/hendricius/diy-proofing-box) - Build your own DIY proofing box for sourdough, yoghurt and pizza. Featuring a raspberry pi and night vision.
 - [Mealie](https://github.com/hay-kot/mealie) - Mealie is a self hosted recipe manager and meal planner.
 - [Tandoor Recipes](https://github.com/TandoorRecipes/recipes) - Self-hosted recipe manager with meal planning, shopping lists, and cookbook organization.
+- [MealThinker](https://mealthinker.com) - AI meal planner that remembers your preferences, dietary needs, and kitchen inventory to suggest personalized meals and reduce food waste.
 - [grocy](https://github.com/grocy/grocy) - Web-based self-hosted groceries and household management solution with recipe and meal planning features.
 - [Nextcloud Cookbook](https://github.com/nextcloud/cookbook) - Recipe management app for the Nextcloud platform.
 - [Recipya](https://github.com/reaper47/recipya) - A clean, simple and powerful self-hosted recipe manager.


### PR DESCRIPTION
Adds [MealThinker](https://mealthinker.com) to the Food-related projects section, alongside other meal planning tools like Mealie and Tandoor Recipes.

MealThinker is an AI meal planner that remembers user preferences, dietary needs, and kitchen inventory to suggest personalized meals and reduce food waste by prioritizing expiring ingredients.

Available on web and iOS.